### PR TITLE
Retrieve jwt from controller

### DIFF
--- a/src/Unosquare.Labs.EmbedIO.BearerToken/BearerTokenModule.cs
+++ b/src/Unosquare.Labs.EmbedIO.BearerToken/BearerTokenModule.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.IdentityModel.Tokens;
-using System;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Text;
 using Unosquare.Swan;
@@ -14,8 +12,7 @@ namespace Unosquare.Labs.EmbedIO.BearerToken
     /// </summary>
     public class BearerTokenModule : WebModuleBase
     {
-        private const string AuthorizationHeader = "Authorization";
-
+        
         /// <summary>
         /// Module's Constructor
         /// </summary>
@@ -59,28 +56,9 @@ namespace Unosquare.Labs.EmbedIO.BearerToken
             {
                 if (routes != null && routes.Contains(context.RequestPath()) == false) return Task.FromResult(false);
 
-                var authHeader = context.RequestHeader(AuthorizationHeader);
-
-                if (string.IsNullOrWhiteSpace(authHeader) == false && authHeader.StartsWith("Bearer "))
-                {
-                    try
-                    {
-                        var token = authHeader.Replace("Bearer ", string.Empty);
-                        var tokenHandler = new JwtSecurityTokenHandler();
-                        SecurityToken validatedToken;
-                        tokenHandler.ValidateToken(token, new TokenValidationParameters
-                        {
-                            ValidateIssuer = false,
-                            ValidateAudience = false,
-                            IssuerSigningKey = secretKey
-                        }, out validatedToken);
-
-                        return Task.FromResult(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        ex.Log(nameof(BearerTokenModule));
-                    }
+                // decode token to see if it's valid
+                if (context.GetSecurityToken(secretKey) != null) {
+                    return Task.FromResult(false);
                 }
 
                 context.Rejected();


### PR DESCRIPTION
Hi, 

One problem with the the BearerTokenModule is : How to retrieve claims from the JWT from a controller (WebApiModule) ?

This patch  add a new `GetSecurityToken()` extension : it will be used by the BearerTokenModule and all controllers from which we want to retrieve claims.

Code snippet from a WebApiModule controller :

```C#
        [WebApiHandler(HttpVerbs.Get, RestApi.RelativePath + "foo/index")]
        public bool Index(WebServer server, HttpListenerContext context) {
            var jwt = context.GetSecurityToken("secretkey") as System.IdentityModel.Tokens.Jwt.JwtSecurityToken;

            var email = jwt?.Claims.First(claim => claim.Type == ClaimTypes.Email).Value;
            
            ...
        }
```

The downside is that the token is parsed 2 times, maybe there is a better way to do this...
